### PR TITLE
remove email

### DIFF
--- a/zh_cn/chapter_02/protocols/shadowsocks.md
+++ b/zh_cn/chapter_02/protocols/shadowsocks.md
@@ -54,7 +54,6 @@
 {
   "servers": [
     {
-      "email": "love@v2ray.com",
       "address": "127.0.0.1",
       "port": 1234,
       "method": "加密方式",
@@ -67,7 +66,6 @@
 
 其中：
 
-* `email`: 邮箱地址，用于标识用户；
 * `address`: Shadowsocks 服务器地址，支持 IPv4、IPv6 和域名。
 * `port`: 服务器端口。
 * `method`: 加密方式，没有默认值。可选的值有：


### PR DESCRIPTION
1. 当客户端和服务器都添加了email 时，email 的值不一样也可正常连接
2. 到目前为止 email 的用途只在路由，我测试过路由中的 emil 规则只与 outbound 的 email 有关
3. 参考 VMess，只有 inbound 有 email 键，outbound 没有

根据以上 3 点，我判断 Shadowsocks 中 outbound 也是没有 email 的