### PR TITLE
Transport/TLS: Add support for ChaCha20-Poly1305

### DIFF
--- a/en/configuration/transport.md
+++ b/en/configuration/transport.md
@@ -48,7 +48,7 @@
 
 * `network`: 数据流所使用的网络，可选的值为 `"tcp"`、 `"kcp"` 或 `"ws"`，默认值为 `"tcp"`；
 * `security`: 是否启入传输层加密，支持的选项有 `"none"` 表示不加密（默认值），`"tls"` 表示使用 [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security)。
-* `tlsSettings`: TLS 配置。TLS 由 Golang 提供，支持 TLS 1.2，不支持 ChaCha 加密方式，不支持 DTLS。
+* `tlsSettings`: TLS 配置。TLS 由 Golang 提供，支持 TLS 1.2，不支持 DTLS。
   * `serverName`: 指定服务器端证书的域名，在连接由 IP 建立时有用。
   * `allowInsecure`: 是否允许不安全连接（用于客户端）。当值为 true 时，V2Ray 不会检查远端主机所提供的 TLS 证书的有效性。
   * `certificates`: 证书列表（用于服务器端），其中每一项表示一个证书：

--- a/zh_cn/chapter_02/05_transport.md
+++ b/zh_cn/chapter_02/05_transport.md
@@ -48,7 +48,7 @@
 
 * `network`: 数据流所使用的网络，可选的值为 `"tcp"`、 `"kcp"` 或 `"ws"`，默认值为 `"tcp"`；
 * `security`: 是否启入传输层加密，支持的选项有 `"none"` 表示不加密（默认值），`"tls"` 表示使用 [TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security)。
-* `tlsSettings`: TLS 配置。TLS 由 Golang 提供，支持 TLS 1.2，不支持 ChaCha 加密方式，不支持 DTLS。
+* `tlsSettings`: TLS 配置。TLS 由 Golang 提供，支持 TLS 1.2，不支持 DTLS。
   * `serverName`: 指定服务器端证书的域名，在连接由 IP 建立时有用。
   * `allowInsecure`: 是否允许不安全连接（用于客户端）。当值为 true 时，V2Ray 不会检查远端主机所提供的 TLS 证书的有效性。
   * `certificates`: 证书列表（用于服务器端），其中每一项表示一个证书：


### PR DESCRIPTION
Package crypto/tls has enabled ChaCha20-Poly1305 cipher suites by default with
[35e5fd0](https://go.googlesource.com/go/+/35e5fd0c4de88567aefa354ce6613b7d1ec3a4d9).

V2ray compiled with latest go crypto/tls source codes should support ChaCha20
-Poly1305 cipher out-of-the-box.

When Android or iPhone devices connect to server preferring ChaCha20-Poly1305,
 ECDHE-ECDSA-CHACHA20-POLY1305 is logged as $ssl_cipher on most http servers.