### PR TITLE
Improve Linux Install Script

### DIFF
--- a/en/welcome/install.md
+++ b/en/welcome/install.md
@@ -49,7 +49,7 @@ The following command assumes root permission.
 Run the following command to install V2Ray. If yum or apt is available, the script will install unzip and daemon / systemd. They are required to run V2Ray as a service. You need to install them manually if your Linux system doesn't support yum or apt.
 
 ```bash
-bash <(curl -L -s https://install.direct/go.sh)
+curl -Ls https://install.direct/go.sh | sudo bash
 ```
 
 The script installs the following files.


### PR DESCRIPTION
Install script required root user. Prepending `sudo` to current command does not works and makes this error

```bash
$ sudo bash <(curl -L -s https://install.direct/go.sh)

bash: /proc/self/fd/11: No such file or directory
```

Using `curl -Ls https://install.direct/go.sh | sudo bash` it runs by root by default :) 