### PR TITLE
delete speedtest

### DIFF
--- a/en/configuration/routing.md
+++ b/en/configuration/routing.md
@@ -191,5 +191,4 @@ This is a domain lists maintained by [domain-list-community](https://github.com/
 * `facebook`: All Facebook domains.
 * `geolocation-cn`: Common domains that serve in China.
 * `geolocation-!cn`: Common domains that don't serve in China
-* `speedtest`: All domains used by Speedtest.
 * `tld-cn`: All .cn and .中国 domains.

--- a/es/configuration/routing.md
+++ b/es/configuration/routing.md
@@ -191,5 +191,4 @@ This is a domain lists maintained by [domain-list-community](https://github.com/
 * `facebook`: All Facebook domains.
 * `geolocation-cn`: Common domains that serve in China.
 * `geolocation-!cn`: Common domains that don't serve in China
-* `speedtest`: All domains used by Speedtest.
 * `tld-cn`: All .cn and .中国 domains.

--- a/fa/configuration/routing.md
+++ b/fa/configuration/routing.md
@@ -191,5 +191,4 @@ This is a domain lists maintained by [domain-list-community](https://github.com/
 * `facebook`: All Facebook domains.
 * `geolocation-cn`: Common domains that serve in China.
 * `geolocation-!cn`: Common domains that don't serve in China
-* `speedtest`: All domains used by Speedtest.
 * `tld-cn`: All .cn and .中国 domains.

--- a/ko/configuration/routing.md
+++ b/ko/configuration/routing.md
@@ -191,5 +191,4 @@ This is a domain lists maintained by [domain-list-community](https://github.com/
 * `facebook`: All Facebook domains.
 * `geolocation-cn`: Common domains that serve in China.
 * `geolocation-!cn`: Common domains that don't serve in China
-* `speedtest`: All domains used by Speedtest.
 * `tld-cn`: All .cn and .中国 domains.

--- a/ru/configuration/routing.md
+++ b/ru/configuration/routing.md
@@ -191,5 +191,4 @@ This is a domain lists maintained by [domain-list-community](https://github.com/
 * `facebook`: All Facebook domains.
 * `geolocation-cn`: Common domains that serve in China.
 * `geolocation-!cn`: Common domains that don't serve in China
-* `speedtest`: All domains used by Speedtest.
 * `tld-cn`: All .cn and .中国 domains.

--- a/vi/configuration/routing.md
+++ b/vi/configuration/routing.md
@@ -191,5 +191,4 @@ This is a domain lists maintained by [domain-list-community](https://github.com/
 * `facebook`: All Facebook domains.
 * `geolocation-cn`: Common domains that serve in China.
 * `geolocation-!cn`: Common domains that don't serve in China
-* `speedtest`: All domains used by Speedtest.
 * `tld-cn`: All .cn and .中国 domains.

--- a/zh_cn/chapter_02/03_routing.md
+++ b/zh_cn/chapter_02/03_routing.md
@@ -189,5 +189,4 @@ V2Ray 内建了一个简单的路由功能，可以将入站数据按需求由�
 * `facebook`: 包含了 Facebook 旗下的所有域名。
 * `geolocation-cn`: 包含了常见的国内站点的域名。
 * `geolocation-!cn`: 包含了常见的非国内站点的域名。
-* `speedtest`: 包含了所有 Speedtest 所用的域名。
 * `tld-cn`: 包含了所有 .cn 和 .中国 结尾的域名。


### PR DESCRIPTION
speedtest 在 domain-list-community 项目中已删除（[Remove speedtest due to #285. Fixes #285](https://github.com/v2ray/domain-list-community/pull/286) ），在最新版 core 中（V4.23.1）使用 speedtest 会导致配置错误无法启动。

domain-list-community 发现bug后用一个空的文件来实现向后兼容（ [Fix: geosite:speedtest not found error](https://github.com/v2ray/domain-list-community/pull/333)），但在下一次 core 正式版本发布前该bug仍存在。

鉴于 speedtest 已不支持。应删除文档内的信息，避免误用。